### PR TITLE
Switch back to relative imports once inside one of the modules in lib

### DIFF
--- a/lib/RawVersion/LoadExcelInputs.py
+++ b/lib/RawVersion/LoadExcelInputs.py
@@ -21,9 +21,9 @@ from openpyxl import load_workbook
 from openpyxl.worksheet.cell_range import CellRange
 
 from . import LoadExp as exp
-from lib.AfoLogic import StructuralInputs as sinp
-from lib.AfoLogic import UniversalInputs as uinp
-from lib.AfoLogic import PropertyInputs as pinp
+from ..AfoLogic import StructuralInputs as sinp
+from ..AfoLogic import UniversalInputs as uinp
+from ..AfoLogic import PropertyInputs as pinp
 
 
 def f_load_stubble():

--- a/lib/RawVersion/LoadExp.py
+++ b/lib/RawVersion/LoadExp.py
@@ -20,8 +20,8 @@ import sys
 import glob
 from datetime import datetime
 
-from lib.AfoLogic import Functions as fun
-from lib.AfoLogic import Exceptions as exc
+from ..AfoLogic import Functions as fun
+from ..AfoLogic import Exceptions as exc
 
 def f_read_exp(pinp_req=False):
     '''

--- a/lib/RawVersion/RawVersionReportExtras.py
+++ b/lib/RawVersion/RawVersionReportExtras.py
@@ -3,7 +3,7 @@ import numpy as np
 import sys
 import os
 
-from lib.AfoLogic import ReportFunctions as rfun
+from ..AfoLogic import ReportFunctions as rfun
 
 
 def f_create_report_dfs(non_exist_trials):

--- a/lib/RawVersion/SaveOutputs.py
+++ b/lib/RawVersion/SaveOutputs.py
@@ -6,9 +6,9 @@ import os.path
 import pickle as pkl
 import warnings
 
-from lib.AfoLogic import Functions as fun
-from lib.AfoLogic import PropertyInputs as pinp
-from lib.AfoLogic import FeedSupplyStock as fsstk
+from ..AfoLogic import Functions as fun
+from ..AfoLogic import PropertyInputs as pinp
+from ..AfoLogic import FeedSupplyStock as fsstk
 
 def f_save_trial_outputs(exp_data, row, trial_name, model, profit, lp_vars, r_vals, pkl_fs_info, d_rot_info):
     ##check Output folders exist for outputs. If not create.


### PR DESCRIPTION
While your entrypoint then needs to use lib.* to do its imports (and ours need to do app.module.afo.lib.* for imports) inside the modules they need to relative import each other otherwise python gets confused.