### PR TITLE
Load the python files relative to the LoadExp file

### DIFF
--- a/lib/RawVersion/LoadExp.py
+++ b/lib/RawVersion/LoadExp.py
@@ -96,7 +96,12 @@ def f_run_required(exp_data1, l_pinp):
 
     ##calc if any code has been changed since AFO was last run
     ###if only ReportControl.py or ReportFunctions.py have been updated precalcs don't need to be re-run therefore newest is equal to the newest py file that isn't a report
-    sorted_list = sorted(glob.iglob('lib/AfoLogic/*.py'), key=os.path.getmtime)
+
+    path_to_afo = "../AfoLogic"
+    directory_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path_to_afo)
+    python_files_dir = os.path.join(directory_path, "*.py")
+    
+    sorted_list = sorted(glob.iglob(python_files_dir), key=os.path.getmtime)
     if sorted_list[-1] != 'ReportFunctions.py' and sorted_list[-1] != 'ReportControl.py':
         newest = sorted_list[-1]
     elif sorted_list[-2] != 'ReportFunctions.py' and sorted_list[-2] != 'ReportControl.py':


### PR DESCRIPTION
Having issues loading in the python files, change it to the importing code we are using for the excel files fixes it. Please test to see if it breaks anything on your end.