### PR TITLE
Some changes to get it running

### DIFF
--- a/lib/AfoLogic/CorePyomo.py
+++ b/lib/AfoLogic/CorePyomo.py
@@ -144,7 +144,7 @@ def coremodel_all(trial_name,model,nv):
 
     path_to_output_infeasible = "../../Output/infeasible"
     directory_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path_to_output_infeasible)
-    trial_file_path = os.path.join(directory_path, trial_name)
+    infeasible_trial_file_path = os.path.join(directory_path, trial_name)
 
     ##this check if the solver is optimal - if infeasible or error the model will save a file in Output/infeasible/ directory. This will be accessed in reporting to stop you reporting infeasible trials.
     ##the model will keep running the next trials even if one is infeasible.
@@ -153,18 +153,18 @@ def coremodel_all(trial_name,model,nv):
         print('OPTIMAL LP SOLUTION FOUND')  # Do nothing when the solution in optimal and feasible
         ###trys to delete the infeasible file because the trial is now optimal
         try:
-            os.remove(trial_file_path)
+            os.remove(infeasible_trial_file_path)
         except FileNotFoundError:
             pass
     elif (solver_result.solver.termination_condition == pe.TerminationCondition.infeasible):
         print('***INFEASIBLE LP SOLUTION***')
         ###save infeasible file
-        with open(trial_file_path,'w') as f:
+        with open(infeasible_trial_file_path,'w') as f:
             f.write("Solver Status: {0}".format(solver_result.solver.termination_condition))
     else:  # Something else is wrong - solver may have stalled.
         print('***Solver Status: error (other)***')
         ###save infeasible file
-        with open(trial_file_path,'w') as f:
+        with open(infeasible_trial_file_path,'w') as f:
             f.write("Solver Status: {0}".format(solver_result.solver.termination_condition))
 
     return profit, utility

--- a/lib/AfoLogic/CorePyomo.py
+++ b/lib/AfoLogic/CorePyomo.py
@@ -123,7 +123,7 @@ def coremodel_all(trial_name,model,nv):
         ##solve with glpk
         solver = pe.SolverFactory('glpk')
         solver.options['tmlim'] = 100  # limit solving time to 100sec in case solver stalls.
-    solver_result = solver.solve(model, tee=True)  # tee=True for solver output - may be useful for troubleshooting, currently warmstart doesnt do anything (could only get it to work for MIP)
+    solver_result = solver.solve(model, warmstart=True, tee=True)  # tee=True for solver output - may be useful for troubleshooting, currently warmstart doesnt do anything (could only get it to work for MIP)
 
     ##calc profit - profit = terminal wealth (this is the objective without risk) + minroe + asset_cost
     try:  # to handle infeasible (there is no profit component when infeasible)


### PR DESCRIPTION
Im having to make these changes to get it to run (even just through RunAfoRaw.py) but im afraid im in too deep as im now getting this as an error and totally lost.

```
Traceback (most recent call last):
  File "/app/app/module/afo/RunAfoRaw.py", line 50, in <module>
    out.f_save_trial_outputs(exp_data, row, trial_name, model, profit, lp_vars, r_vals, pkl_fs_info, d_rot_info)
  File "/app/app/module/afo/lib/RawVersion/SaveOutputs.py", line 58, in f_save_trial_outputs
    if c[index].uslack() != 0 and c[index].lslack() != np.inf:
  File "/usr/local/lib/python3.8/site-packages/pyomo/core/base/constraint.py", line 194, in uslack
    return ub - value(self.body)
  File "pyomo/core/expr/numvalue.pyx", line 153, in pyomo.core.expr.numvalue.value
  File "pyomo/core/expr/numvalue.pyx", line 138, in pyomo.core.expr.numvalue.value
  File "/usr/local/lib/python3.8/site-packages/pyomo/core/expr/base.py", line 115, in __call__
    return evaluate_expression(self, exception)
  File "/usr/local/lib/python3.8/site-packages/pyomo/core/expr/visitor.py", line 1242, in evaluate_expression
    ans = visitor.dfs_postorder_stack(exp)
  File "/usr/local/lib/python3.8/site-packages/pyomo/core/expr/visitor.py", line 880, in dfs_postorder_stack
    flag, value = self.visiting_potential_leaf(_sub)
  File "/usr/local/lib/python3.8/site-packages/pyomo/core/expr/visitor.py", line 1144, in visiting_potential_leaf
    return True, value(node, exception=self.exception)
  File "pyomo/core/expr/numvalue.pyx", line 153, in pyomo.core.expr.numvalue.value
  File "pyomo/core/expr/numvalue.pyx", line 140, in pyomo.core.expr.numvalue.value
ValueError: No value for uninitialized NumericValue object v_phase_area[q0,s0,zm0,typ,AAAA2A1a,lmu2]
```

I think changing the file dir over to the relative path should be fine but im not sure about taking out warmstart, with it in I got an error saying it wasn't an allowed flag

```
Traceback (most recent call last):
  File "/app/app/module/afo/RunAfoRaw.py", line 44, in <module>
    model, profit, lp_vars, r_vals, pkl_fs_info, d_rot_info = afo.exp(user_sa, property, trial_name, trial_description, sinp_defaults, uinp_defaults, pinp_defaults, d_rot_info, cat_propn_s1_ks2)
  File "/app/app/module/afo/lib/AfoLogic/AfoInit.py", line 171, in exp
    profit, obj = core.coremodel_all(trial_name, model, nv)
  File "/app/app/module/afo/lib/AfoLogic/CorePyomo.py", line 126, in coremodel_all
    solver_result = solver.solve(model, warmstart=True, tee=True)  # tee=True for solver output - may be useful for troubleshooting, currently warmstart doesnt do anything (could only get it to work for MIP)
  File "/usr/local/lib/python3.8/site-packages/pyomo/opt/base/solvers.py", line 570, in solve
    self._presolve(*args, **kwds)
  File "/usr/local/lib/python3.8/site-packages/pyomo/opt/solver/shellcmd.py", line 219, in _presolve
    OptSolver._presolve(self, *args, **kwds)
  File "/usr/local/lib/python3.8/site-packages/pyomo/opt/base/solvers.py", line 667, in _presolve
    self._convert_problem(args,
  File "/usr/local/lib/python3.8/site-packages/pyomo/opt/base/solvers.py", line 718, in _convert_problem
    return convert_problem(args,
  File "/usr/local/lib/python3.8/site-packages/pyomo/opt/base/convert.py", line 101, in convert_problem
    problem_files, symbol_map = converter.apply(*tmp, **tmpkw)
  File "/usr/local/lib/python3.8/site-packages/pyomo/solvers/plugins/converter/model.py", line 79, in apply
    (problem_filename, symbol_map_id) = instance.write(
  File "/usr/local/lib/python3.8/site-packages/pyomo/core/base/block.py", line 2016, in write
    (filename, smap) = problem_writer(self,
  File "pyomo/repn/plugins/cpxlp.pyx", line 132, in pyomo.repn.plugins.cpxlp.ProblemWriter_cpxlp.__call__
ValueError: ProblemWriter_cpxlp passed unrecognized io_options:
        warmstart = True
```

And heres the error for the output

```
Traceback (most recent call last):
  File "/app/app/module/afo/RunAfoRaw.py", line 44, in <module>
    model, profit, lp_vars, r_vals, pkl_fs_info, d_rot_info = afo.exp(user_sa, property, trial_name, trial_description, sinp_defaults, uinp_defaults, pinp_defaults, d_rot_info, cat_propn_s1_ks2)
  File "/app/app/module/afo/lib/AfoLogic/AfoInit.py", line 171, in exp
    profit, obj = core.coremodel_all(trial_name, model, nv)
  File "/app/app/module/afo/lib/AfoLogic/CorePyomo.py", line 163, in coremodel_all
    with open('Output/infeasible/%s.txt' % trial_name,'w') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'Output/infeasible/Model Standard Original.txt'
```